### PR TITLE
fix: exclude Makefile symlinks from sdist to fix hatchling build

### DIFF
--- a/libs/langchain-cloudflare/pyproject.toml
+++ b/libs/langchain-cloudflare/pyproject.toml
@@ -46,6 +46,9 @@ test = [
 [tool.hatch.build.targets.wheel]
 packages = ["langchain_cloudflare"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["Makefile"]
+
 [tool.mypy]
 disallow_untyped_defs = true
 exclude = [

--- a/libs/langgraph-checkpoint-cloudflare-d1/pyproject.toml
+++ b/libs/langgraph-checkpoint-cloudflare-d1/pyproject.toml
@@ -42,6 +42,9 @@ test = [
 [tool.hatch.build.targets.wheel]
 packages = ["langgraph_checkpoint_cloudflare_d1"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["Makefile"]
+
 [tool.mypy]
 disallow_untyped_defs = true
 


### PR DESCRIPTION
## Summary
- Exclude Makefile symlinks from source distributions in both `langchain-cloudflare` and `langgraph-checkpoint-cloudflare-d1` packages
- Fixes `uv build` failure caused by hatchling rejecting symlinks pointing outside the package directory

## Root Cause
The Makefile in each lib directory is a symlink to `../../Makefile`. Hatchling (the build backend) rejects symlinks pointing outside the package directory for security reasons. This worked with Poetry but fails with the new uv + hatchling setup.

## Test plan
- [x] Verified `uv build` succeeds locally for both packages
- [ ] CI should pass the "Build project for distribution" step