### PR TITLE
fix: resolve mypy 1.20 errors in vectorstores

### DIFF
--- a/libs/langchain-cloudflare/langchain_cloudflare/vectorstores.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/vectorstores.py
@@ -3198,8 +3198,6 @@ class CloudflareVectorize(VectorStore):
         Raises:
             ValueError: If account_id or index_name is not provided
         """
-        index_name = index_name or cls.index_name
-
         if not account_id or not index_name:
             raise ValueError("account_id and index_name must be provided")
 
@@ -3289,9 +3287,6 @@ class CloudflareVectorize(VectorStore):
         Raises:
             ValueError: If account_id or index_name is not provided
         """
-
-        index_name = index_name or cls.index_name
-
         if not account_id or not index_name:
             raise ValueError("account_id and index_name must be provided")
 
@@ -3372,8 +3367,6 @@ class CloudflareVectorize(VectorStore):
         Raises:
             ValueError: If the number of documents exceeds MAX_INSERT_SIZE.
         """
-        index_name = index_name or cls.index_name
-
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
 
@@ -3444,8 +3437,6 @@ class CloudflareVectorize(VectorStore):
         Raises:
             ValueError: If the number of documents exceeds MAX_INSERT_SIZE.
         """
-        index_name = index_name or cls.index_name
-
         texts = [doc.page_content for doc in documents]
         metadatas = [doc.metadata for doc in documents]
 

--- a/libs/langchain-cloudflare/pyproject.toml
+++ b/libs/langchain-cloudflare/pyproject.toml
@@ -29,7 +29,7 @@ async = ["greenlet>=3.0.0"]
 [dependency-groups]
 dev = [
     "ruff>=0.8.4",
-    "mypy>=1.15.0",
+    "mypy>=1.15.0,<2.0.0",
     "codespell>=2.2.6",
     "types-requests>=2.31.0",
 ]


### PR DESCRIPTION
## Summary

- Remove invalid `cls.index_name` fallback in 4 vectorstores classmethods (`from_texts`, `afrom_texts`, `from_documents`, `afrom_documents`) — `index_name` is instance-only, not a class attribute
- Cap mypy to `<2.0.0` to prevent unpinned minor releases from breaking CI

## Test plan

- [x] `make lint` passes (ruff + mypy)
- [x] Pre-commit hooks pass