### PR TITLE
feat: add @cf/google/gemma-4-26b-a4b-it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## langchain-cloudflare
 
+### [0.3.2]
+
+#### Added
+
+- **`@cf/google/gemma-4-26b-a4b-it`**: Adds Gemma 4 26B with reasoning content extraction, tool calling, structured output, and vision (image base64) support.
+
+---
+
 ### [0.3.1]
 
 #### Added

--- a/libs/langchain-cloudflare/examples/workers/src/entry.py
+++ b/libs/langchain-cloudflare/examples/workers/src/entry.py
@@ -37,6 +37,7 @@ SUPPORTED_MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/google/gemma-4-26b-a4b-it",
 ]
 
 DEFAULT_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8"

--- a/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
@@ -194,6 +194,7 @@ MODEL_BEHAVIORS: Dict[str, ModelBehavior] = {
         unsupported_params=("max_tokens", "top_k", "repetition_penalty", "tool_choice"),
         supports_reasoning_content=True,
     ),
+    "gemma": _REASONING_BEHAVIOR,
     "gpt-oss": _REASONING_BEHAVIOR,
     "kimi": _REASONING_BEHAVIOR,
     "llama": ModelBehavior(embed_tool_calls_in_content=True),

--- a/libs/langchain-cloudflare/pyproject.toml
+++ b/libs/langchain-cloudflare/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-cloudflare"
-version = "0.3.1"
+version = "0.3.2"
 description = "Langchain Integrations for Cloudflare's WorkersAI and Vectorize"
 readme = "README.md"
 license = "MIT"

--- a/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
@@ -35,6 +35,7 @@ MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/google/gemma-4-26b-a4b-it",
 ]
 
 
@@ -871,6 +872,7 @@ class TestWorkerReasoningContent:
         "@cf/openai/gpt-oss-20b",
         "@cf/moonshotai/kimi-k2.5",
         "@cf/nvidia/nemotron-3-120b-a12b",
+        "@cf/google/gemma-4-26b-a4b-it",
     ]
 
     @pytest.mark.parametrize("model", REASONING_MODELS)

--- a/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
@@ -64,6 +64,7 @@ MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/google/gemma-4-26b-a4b-it",
 ]
 
 
@@ -705,6 +706,7 @@ class TestReasoningContent:
         "@cf/openai/gpt-oss-120b",
         "@cf/openai/gpt-oss-20b",
         "@cf/moonshotai/kimi-k2.5",
+        "@cf/google/gemma-4-26b-a4b-it",
         "@cf/nvidia/nemotron-3-120b-a12b",
     ]
 


### PR DESCRIPTION
## Summary

- Adds `@cf/google/gemma-4-26b-a4b-it` (256K context, Google Gemma 4)
- Registers `"gemma"` in `MODEL_BEHAVIORS` with `supports_reasoning_content=True` — model returns reasoning via `reasoning_effort`/`enable_thinking`
- Adds model to all `MODELS`, `REASONING_MODELS`, and `SUPPORTED_MODELS` lists

Closes #38

## Test plan

- [x] Unit tests: 85 passed
- [x] REST API integration: reasoning, tool calling, vision (image base64) all pass
- [x] Worker integration: all Gemma-specific tests pass
- [x] Lint: ruff + mypy clean