### PR TITLE
feat: add kimi-k2.6 and harden structured output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ install_and_test.sh
 **/.ruff_cache/
 .benchmarks/
 .claude/
+.codex/
+AGENTS.md
 uv.lock
 python_modules/
 .venv-workers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## langchain-cloudflare
 
+### [0.3.4]
+
+#### Changed
+
+- **Structured output routing**: Adds `method="json_schema"` as a first-class `with_structured_output()` option, fixes prompt-value schema injection, and normalizes dict-shaped model responses before constructing `AIMessage` content blocks.
+- **Workers test startup**: Makes Wrangler startup non-interactive and prefers a modern `~/.nvm` Node runtime in Worker test fixtures so the full Worker suite can start reliably on machines with an older system Node in `PATH`.
+- **Vectorize readiness polling**: Hardens `create_index(wait=True)` / `acreate_index(wait=True)` readiness checks and makes the namespace integration test poll for query visibility instead of assuming immediate consistency.
+
+#### Added
+
+- **`@cf/moonshotai/kimi-k2.6`**: Adds Kimi K2.6 to the tested and example-supported model lists with verified reasoning content, multi-turn tool calling, structured output, and vision support on Workers AI.
+
+---
+
+### [0.3.3]
+
+#### Fixed
+
+- **Gemma structured output**: Gemma (`@cf/google/gemma-4-26b-a4b-it`) intermittently omitted required fields when using tool calling for `with_structured_output`. Switched to `json_object` response format with schema injected via system message for reliable output. Adds `use_json_object_for_structured_output` flag to `ModelBehavior` for future use with other models exhibiting the same behavior.
+
+---
+
 ### [0.3.2]
 
 #### Added

--- a/libs/langchain-cloudflare/examples/workers/package.json
+++ b/libs/langchain-cloudflare/examples/workers/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "uv run pywrangler sync && ./scripts/setup_pyodide_deps.sh && npx wrangler dev",
-    "deploy": "uv run pywrangler sync && ./scripts/setup_pyodide_deps.sh && npx wrangler deploy",
+    "dev": "uv run pywrangler sync && ./scripts/setup_pyodide_deps.sh && npx --yes wrangler dev",
+    "deploy": "uv run pywrangler sync && ./scripts/setup_pyodide_deps.sh && npx --yes wrangler deploy",
     "start": "uv run pywrangler dev"
   },
   "devDependencies": {

--- a/libs/langchain-cloudflare/examples/workers/src/entry.py
+++ b/libs/langchain-cloudflare/examples/workers/src/entry.py
@@ -37,6 +37,7 @@ SUPPORTED_MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/moonshotai/kimi-k2.6",
     "@cf/google/gemma-4-26b-a4b-it",
 ]
 
@@ -92,6 +93,8 @@ class Default(WorkerEntrypoint):
                 return await self.handle_structured_output(request)
             elif path == "structured-batch":
                 return await self.handle_structured_output_batch(request)
+            elif path == "structured-json-schema":
+                return await self.handle_structured_output_json_schema(request)
             elif path == "tools":
                 return await self.handle_tool_calling(request)
             elif path == "tools-batch":
@@ -438,6 +441,65 @@ Return JSON with an "announcements" array. Each announcement should have:
                 "model": llm.model,
             }
         )
+
+    # MARK: - Structured Output JSON Schema Handler
+
+    async def handle_structured_output_json_schema(self, request):
+        """Handle structured output using method='json_schema'."""
+        from pydantic import ValidationError
+
+        data = await request.json()
+        text = data.get("text", "Acme Corp announced a partnership with TechGiant Inc.")
+        model = data.get("model", DEFAULT_MODEL)
+
+        llm = ChatCloudflareWorkersAI(
+            model_name=model,
+            binding=self.env.AI,
+            temperature=0.0,
+        )
+
+        structured_llm = llm.with_structured_output(Data, method="json_schema")
+
+        prompt = f"""Extract announcements from this text as structured data.
+
+Text: {text}
+
+Return JSON with an "announcements" array. Each announcement should have:
+- type: partnership, investment, regulatory, milestone, event, m&a, or none
+- context: brief description
+- entities: array with name, ticker (optional), and role"""
+
+        try:
+            result = await structured_llm.ainvoke(prompt)
+
+            if isinstance(result, Data):
+                result_dict = result.model_dump()
+            elif isinstance(result, dict):
+                try:
+                    validated = Data(**result)
+                    result_dict = validated.model_dump()
+                except ValidationError:
+                    result_dict = result
+            else:
+                result_dict = {"raw": str(result)}
+
+            return Response.json(
+                {
+                    "input": text,
+                    "extracted": result_dict,
+                    "method": "json_schema",
+                }
+            )
+
+        except ValidationError as e:
+            return Response.json(
+                {
+                    "input": text,
+                    "extracted": {"announcements": []},
+                    "validation_warning": str(e),
+                    "method": "json_schema",
+                }
+            )
 
     # MARK: - Tool Calling Handler
 

--- a/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
@@ -54,7 +54,13 @@ from langchain_core.output_parsers.openai_tools import (
     PydanticToolsParser,
 )
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
+from langchain_core.prompt_values import PromptValue
+from langchain_core.runnables import (
+    Runnable,
+    RunnableLambda,
+    RunnableMap,
+    RunnablePassthrough,
+)
 from langchain_core.tools import BaseTool
 from langchain_core.utils import (
     from_env,
@@ -122,6 +128,29 @@ class ModelBehavior(BaseModel):
             '[{"type": "thinking", "thinking": "..."}, '
             '{"type": "text", "text": "..."}]. '
             "Currently Qwen, GLM, GPT-OSS, and Kimi models expose this."
+        ),
+    )
+
+    use_json_object_for_structured_output: bool = Field(
+        default=False,
+        description=(
+            "When True, with_structured_output uses response_format json_object "
+            "instead of tool calling. Use for models that produce unreliable "
+            "structured output via tool calling. The model is prompted with the "
+            "schema and constrained to valid JSON output."
+        ),
+    )
+
+    json_schema_mode: Literal["json_object", "guided_json", "json_schema_rf"] = Field(
+        default="json_object",
+        description=(
+            "How to implement method='json_schema' for this model family. "
+            "'json_object': bind response_format=json_object and inject schema "
+            "into a system message (default, works for most models). "
+            "'guided_json': bind guided_json=<schema> directly, no injection "
+            "(Mistral). "
+            "'json_schema_rf': bind response_format={type: json_schema, "
+            "json_schema: <schema>}, no injection (GPT-OSS / OpenAI-compatible)."
         ),
     )
 
@@ -194,14 +223,23 @@ MODEL_BEHAVIORS: Dict[str, ModelBehavior] = {
         unsupported_params=("max_tokens", "top_k", "repetition_penalty", "tool_choice"),
         supports_reasoning_content=True,
     ),
-    "gemma": _REASONING_BEHAVIOR,
-    "gpt-oss": _REASONING_BEHAVIOR,
+    "gemma": ModelBehavior(
+        embed_tool_calls_in_content=False,
+        supports_reasoning_content=True,
+        use_json_object_for_structured_output=True,
+    ),
+    "gpt-oss": ModelBehavior(
+        embed_tool_calls_in_content=False,
+        supports_reasoning_content=True,
+        json_schema_mode="json_schema_rf",
+    ),
     "kimi": _REASONING_BEHAVIOR,
     "llama": ModelBehavior(embed_tool_calls_in_content=True),
     "mistral": ModelBehavior(
         embed_tool_calls_in_content=False,
         unsupported_params=("tool_choice",),
         response_format_param="guided_json",
+        json_schema_mode="json_object",
     ),
     "nemotron": _REASONING_BEHAVIOR,
     "qwen": _REASONING_BEHAVIOR,
@@ -228,6 +266,20 @@ def get_model_behavior(model_name: str) -> ModelBehavior:
         if family in model_lower:
             return behavior
     return DEFAULT_MODEL_BEHAVIOR
+
+
+# MARK: - Helper Functions
+
+
+def _normalize_message_content(content: Any) -> str:
+    """Normalize model content into a string accepted by AIMessage."""
+    if content is None:
+        return ""
+    if isinstance(content, dict):
+        return json.dumps(content)
+    if isinstance(content, str):
+        return content
+    return str(content)
 
 
 # MARK: - ChatCloudflareWorkersAI
@@ -1258,12 +1310,12 @@ class ChatCloudflareWorkersAI(BaseChatModel):
             # OpenAI-compatible format (used by Qwen and other models)
             choice = response_result["choices"][0]
             message_data = choice.get("message", {})
-            content = message_data.get("content", "")
+            content = _normalize_message_content(message_data.get("content", ""))
             # Token usage in OpenAI format is at the top level of result
             token_usage = response_result.get("usage", {})
         else:
             # Old Workers AI format
-            content = response_result.get("response", "")
+            content = _normalize_message_content(response_result.get("response", ""))
             token_usage = response_result.get("usage", {})
             message_data = {}  # No message data in old format
         tool_calls = []
@@ -1402,7 +1454,9 @@ class ChatCloudflareWorkersAI(BaseChatModel):
             # Both tool calls and reasoning: surface reasoning as content blocks
             content_blocks: list = [{"type": "thinking", "thinking": reasoning_content}]
             if content:
-                content_blocks.append({"type": "text", "text": content})
+                content_blocks.append(
+                    {"type": "text", "text": _normalize_message_content(content)}
+                )
             message = AIMessage(
                 content=content_blocks,
                 tool_calls=tool_calls,
@@ -1416,14 +1470,13 @@ class ChatCloudflareWorkersAI(BaseChatModel):
             # Content blocks: thinking + text (matches Anthropic/Gemini convention)
             content_blocks = [{"type": "thinking", "thinking": reasoning_content}]
             if content:
-                content_blocks.append({"type": "text", "text": content})
+                content_blocks.append(
+                    {"type": "text", "text": _normalize_message_content(content)}
+                )
             message = AIMessage(content=content_blocks)
         else:
-            # Use empty string if content is None
-            if content is None:
-                content = ""
             message = AIMessage(
-                content=content,
+                content=_normalize_message_content(content),
             )
 
         # Add usage metadata
@@ -1660,7 +1713,9 @@ class ChatCloudflareWorkersAI(BaseChatModel):
         self,
         schema: Optional[Union[Dict, Type[BaseModel]]] = None,
         *,
-        method: Literal["function_calling", "json_mode"] = "function_calling",
+        method: Literal[
+            "function_calling", "json_mode", "json_schema"
+        ] = "function_calling",
         include_raw: bool = False,
         **kwargs: Any,
     ) -> Runnable[LanguageModelInput, Union[Dict, BaseModel]]:
@@ -1669,8 +1724,20 @@ class ChatCloudflareWorkersAI(BaseChatModel):
         Args:
             schema: The output schema (OpenAI function/tool schema, JSON Schema,
                    TypedDict class, or Pydantic class)
-            method: Method for steering model generation
-            ("function_calling" or "json_mode")
+            method: Method for steering model generation.
+
+                - ``"function_calling"`` (default): Use tool calling. For models
+                  that produce unreliable structured output via tool calling (e.g.
+                  Gemma), this automatically falls back to ``"json_schema"``
+                  behavior.
+                - ``"json_schema"``: Constrain output to valid JSON and inject the
+                  schema into a system message. Reliable across models but adds
+                  ~3x more input tokens than tool calling. Intended for use when
+                  tool calling is unreliable or unsupported.
+                - ``"json_mode"``: Use ``response_format: json_object`` without
+                  schema injection. The model infers the structure from your
+                  prompt. Fewest tokens, but least constrained.
+
             include_raw: If True, return both raw and parsed responses
 
         Returns:
@@ -1682,9 +1749,104 @@ class ChatCloudflareWorkersAI(BaseChatModel):
 
         is_pydantic_schema = _is_pydantic_class(schema)
 
-        # Handle special case for json_schema method
-        if method == "json_schema":
-            method = "function_calling"
+        # json_schema: constrain output to valid JSON using the model's native
+        # mechanism. Triggered explicitly via method="json_schema", or
+        # automatically for models that produce unreliable tool-call structured
+        # output (use_json_object_for_structured_output=True).
+        use_json_schema_path = method == "json_schema" or (
+            method == "function_calling"
+            and self._model_behavior.use_json_object_for_structured_output
+        )
+        if use_json_schema_path and schema is not None:
+            if is_pydantic_schema:
+                raw_schema = schema.model_json_schema()  # type: ignore[union-attr]
+            else:
+                raw_schema = schema
+
+            json_schema_mode = self._model_behavior.json_schema_mode
+            output_parser = (
+                CloudflarePydanticOutputParser(pydantic_object=schema)  # type: ignore
+                if is_pydantic_schema
+                else CloudflareJsonOutputParser()
+            )
+
+            if json_schema_mode == "guided_json":
+                # Mistral: bind guided_json=<schema> directly; constrained
+                # decoding handles schema adherence without system message injection.
+                llm = self.bind(  # type: ignore[assignment]
+                    guided_json=raw_schema,
+                    ls_structured_output_format={
+                        "kwargs": {"method": "json_schema"},
+                        "schema": schema,
+                    },
+                )
+                pipeline: Any = llm
+
+            elif json_schema_mode == "json_schema_rf":
+                # GPT-OSS / OpenAI-compatible: use response_format json_schema,
+                # which Cloudflare normalizes correctly. No injection needed.
+                llm = self.bind(  # type: ignore[assignment]
+                    response_format={"type": "json_schema", "json_schema": raw_schema},
+                    ls_structured_output_format={
+                        "kwargs": {"method": "json_schema"},
+                        "schema": schema,
+                    },
+                )
+                pipeline = llm
+
+            else:
+                # Default (json_object): constrain to valid JSON and inject the
+                # schema into a system message so the model knows the structure.
+                schema_str = json.dumps(raw_schema, indent=2)
+                schema_system_msg = SystemMessage(
+                    content=(
+                        "You must respond with valid JSON that matches this schema. "
+                        "Return only the JSON object. Do not include prose, markdown, "
+                        "or tool/function calls.\n"
+                        f"{schema_str}"
+                    )
+                )
+
+                def _inject_schema_message(
+                    messages: LanguageModelInput,
+                ) -> LanguageModelInput:
+                    """Prepend schema system message, merging with existing system if present."""  # noqa: E501
+                    if isinstance(messages, PromptValue):
+                        messages = messages.to_messages()
+                    if isinstance(messages, str):
+                        return [schema_system_msg, HumanMessage(content=messages)]
+                    if isinstance(messages, list):
+                        if messages and isinstance(messages[0], SystemMessage):
+                            existing = messages[0].content
+                            prefix = existing if isinstance(existing, str) else ""
+                            merged = SystemMessage(
+                                content=prefix + "\n\n" + str(schema_system_msg.content)
+                            )
+                            return [merged] + messages[1:]
+                        return [schema_system_msg] + list(messages)
+                    return messages
+
+                llm = self.bind(  # type: ignore[assignment]
+                    response_format={"type": "json_object"},
+                    ls_structured_output_format={
+                        "kwargs": {"method": "json_mode"},
+                        "schema": schema,
+                    },
+                )
+                pipeline = RunnableLambda(_inject_schema_message) | llm  # type: ignore[arg-type]
+
+            if include_raw:
+                parser_assign = RunnablePassthrough.assign(
+                    parsed=itemgetter("raw") | output_parser,  # type: ignore
+                    parsing_error=lambda _: None,
+                )
+                parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+                parser_with_fallback = parser_assign.with_fallbacks(
+                    [parser_none], exception_key="parsing_error"
+                )
+                return RunnableMap(raw=pipeline) | parser_with_fallback
+            else:
+                return pipeline | output_parser
 
         # Configure LLM and create appropriate parser based on method
         if method == "function_calling":
@@ -1731,8 +1893,8 @@ class ChatCloudflareWorkersAI(BaseChatModel):
 
         else:
             raise ValueError(
-                f"Unrecognized method argument. Expected one of 'function_calling' or "
-                f"'json_mode'. Received: '{method}'"
+                f"Unrecognized method argument. Expected one of 'function_calling', "
+                f"'json_mode', or 'json_schema'. Received: '{method}'"
             )
 
         # Configure final output structure based on include_raw flag

--- a/libs/langchain-cloudflare/langchain_cloudflare/vectorstores.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/vectorstores.py
@@ -56,6 +56,12 @@ DEFAULT_METRIC = "cosine"
 VST = TypeVar("VST", bound="CloudflareVectorize")
 
 
+# MARK: - Helper Functions
+def _index_is_ready(index_info: Dict[str, Any]) -> bool:
+    """Return True when an index describe payload looks queryable."""
+    return bool(index_info.get("name") and index_info.get("config"))
+
+
 # MARK: - RequestsKwargs
 class RequestsKwargs(TypedDict, total=False):
     """TypedDict for requests kwargs."""
@@ -1027,8 +1033,8 @@ class CloudflareVectorize(VectorStore):
                 index_mutation_id = response_index.get("processedUpToMutation")
                 if index_mutation_id == mutation_id:
                     break
-            else:
-                return
+            elif _index_is_ready(response_index):
+                break
 
             time.sleep(poll_interval_seconds)
 
@@ -1071,8 +1077,8 @@ class CloudflareVectorize(VectorStore):
                 index_mutation_id = response_index.get("processedUpToMutation")
                 if index_mutation_id == mutation_id:
                     break
-            else:
-                return
+            elif _index_is_ready(response_index):
+                break
 
             await asyncio.sleep(poll_interval_seconds)
 

--- a/libs/langchain-cloudflare/pyproject.toml
+++ b/libs/langchain-cloudflare/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-cloudflare"
-version = "0.3.2"
+version = "0.3.4"
 description = "Langchain Integrations for Cloudflare's WorkersAI and Vectorize"
 readme = "README.md"
 license = "MIT"

--- a/libs/langchain-cloudflare/tests/conftest.py
+++ b/libs/langchain-cloudflare/tests/conftest.py
@@ -44,6 +44,23 @@ def get_worker_project_dir() -> Path:
     return Path(__file__).parent.parent / "examples" / "workers"
 
 
+def _get_nvm_node_bin() -> str | None:
+    """Return the newest installed nvm Node bin dir, if present."""
+    nvm_versions = Path.home() / ".nvm" / "versions" / "node"
+    if not nvm_versions.exists():
+        return None
+
+    bins = sorted(
+        (
+            path / "bin"
+            for path in nvm_versions.iterdir()
+            if (path / "bin" / "node").exists()
+        ),
+        reverse=True,
+    )
+    return str(bins[0]) if bins else None
+
+
 def sync_package_to_python_modules(project_dir: Path) -> None:
     """Copy the latest package source to python_modules for Workers.
 
@@ -103,6 +120,12 @@ def pywrangler_dev_server(
     env.pop("CLOUDFLARE_API_TOKEN", None)
     env.pop("TEST_CF_API_TOKEN", None)
 
+    # Prefer a modern nvm-managed Node when the shell PATH points at an older system
+    # install. Wrangler 4 requires Node >= 20.
+    nvm_node_bin = _get_nvm_node_bin()
+    if nvm_node_bin:
+        env["PATH"] = f"{nvm_node_bin}:{env['PATH']}"
+
     # Step 1: Run pywrangler sync to install Pyodide-compatible deps
     sync_result = subprocess.run(
         ["uv", "run", "pywrangler", "sync"],
@@ -140,7 +163,7 @@ def pywrangler_dev_server(
     # (they don't support local simulation, only remote binding connections)
     # D1 supports both local and remote
     process = subprocess.Popen(
-        ["npx", "wrangler", "dev", "--port", str(port)],
+        ["npx", "--yes", "wrangler", "dev", "--port", str(port)],
         cwd=project_dir,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/libs/langchain-cloudflare/tests/integration_tests/test_vectorstores.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_vectorstores.py
@@ -16,6 +16,7 @@ In order to run this test, you need to:
 
 import json
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Generator, List
@@ -34,6 +35,20 @@ env_path = Path(__file__).parent / ".env"
 load_dotenv(env_path)
 
 MODEL_WORKERSAI = "@cf/baai/bge-large-en-v1.5"
+
+
+def wait_for_search_results(
+    search_fn, timeout_seconds: int = 30, poll_interval_seconds: int = 2
+):
+    """Poll a search callable until it returns at least one result."""
+    deadline = time.time() + timeout_seconds
+    last_results = []
+    while time.time() < deadline:
+        last_results = search_fn()
+        if last_results:
+            return last_results
+        time.sleep(poll_interval_seconds)
+    return last_results
 
 
 @pytest.fixture(scope="class")
@@ -253,8 +268,10 @@ class TestCloudflareVectorize:
         )
 
         # Search within the namespace
-        results = store.similarity_search(
-            query="storage solution", k=2, namespace=test_namespace
+        results = wait_for_search_results(
+            lambda: store.similarity_search(
+                query="storage solution", k=2, namespace=test_namespace
+            )
         )
 
         # Verify results

--- a/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
@@ -35,6 +35,19 @@ MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/moonshotai/kimi-k2.6",
+    "@cf/google/gemma-4-26b-a4b-it",
+]
+
+# Models live-validated in this suite for method='json_schema'.
+# Excluded families stay out of this list until their runtime behavior is
+# verified end-to-end in integration tests.
+JSON_SCHEMA_MODELS = [m for m in MODELS if "mistral" not in m and "gpt-oss" not in m]
+
+# Models confirmed to support vision (image input). Per CF docs and live testing.
+VISION_MODELS = [
+    "@cf/moonshotai/kimi-k2.5",
+    "@cf/moonshotai/kimi-k2.6",
     "@cf/google/gemma-4-26b-a4b-it",
 ]
 
@@ -149,6 +162,31 @@ class TestWorkerStructuredOutput:
 
         assert "input" in data
         assert "extracted" in data
+        assert "announcements" in data["extracted"] or "raw" in data["extracted"]
+
+
+class TestWorkerStructuredOutputJsonSchema:
+    """Test structured output with method='json_schema' via Worker binding."""
+
+    @pytest.mark.parametrize("model", JSON_SCHEMA_MODELS)
+    def test_structured_output_json_schema(self, dev_server, model):
+        """POST /structured-json-schema should work for any model."""
+        port = dev_server
+        response = requests.post(
+            f"http://localhost:{port}/structured-json-schema",
+            json={
+                "text": "Acme Corp announced a partnership with TechGiant Inc.",
+                "model": model,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "input" in data
+        assert "extracted" in data
+        assert data.get("method") == "json_schema"
         assert "announcements" in data["extracted"] or "raw" in data["extracted"]
 
 
@@ -871,6 +909,7 @@ class TestWorkerReasoningContent:
         "@cf/openai/gpt-oss-120b",
         "@cf/openai/gpt-oss-20b",
         "@cf/moonshotai/kimi-k2.5",
+        "@cf/moonshotai/kimi-k2.6",
         "@cf/nvidia/nemotron-3-120b-a12b",
         "@cf/google/gemma-4-26b-a4b-it",
     ]
@@ -1026,6 +1065,44 @@ class TestWorkerMultiModal:
         assert response.status_code == 400
         data = response.json()
         assert "error" in data
+
+
+# MARK: - Vision Model Regression Tests
+
+
+class TestWorkerVisionModels:
+    """Regression tests for confirmed vision-capable models via Worker binding.
+
+    Unlike TestWorkerMultiModal (which skips failures), these tests assert that
+    VISION_MODELS must successfully process image input. A failure here means
+    vision support regressed for a model we know should work.
+    """
+
+    @pytest.mark.parametrize("model", VISION_MODELS)
+    def test_vision_invoke(self, dev_server, model):
+        """Vision models must return a non-empty response for image input."""
+        port = dev_server
+        image_b64 = create_test_image_base64()
+
+        response = requests.post(
+            f"http://localhost:{port}/multi-modal",
+            json={
+                "model": model,
+                "image_base64": image_b64,
+                "prompt": "Describe this image in one sentence. What color is it?",
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+
+        assert response.status_code == 200, (
+            f"Vision model {model} failed with: {response.text}"
+        )
+        data = response.json()
+        assert "response" in data
+        assert len(data["response"]) > 0, (
+            f"Expected non-empty vision response from {model}"
+        )
 
 
 # MARK: - Session Affinity (Prompt Caching) Tests

--- a/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
@@ -64,6 +64,19 @@ MODELS = [
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",
     "@cf/moonshotai/kimi-k2.5",
+    "@cf/moonshotai/kimi-k2.6",
+    "@cf/google/gemma-4-26b-a4b-it",
+]
+
+# Models live-validated in this suite for method='json_schema'.
+# Excluded families stay out of this list until their runtime behavior is
+# verified end-to-end in integration tests.
+JSON_SCHEMA_MODELS = [m for m in MODELS if "mistral" not in m and "gpt-oss" not in m]
+
+# Models confirmed to support vision (image input). Per CF docs and live testing.
+VISION_MODELS = [
+    "@cf/moonshotai/kimi-k2.5",
+    "@cf/moonshotai/kimi-k2.6",
     "@cf/google/gemma-4-26b-a4b-it",
 ]
 
@@ -220,6 +233,37 @@ class TestStructuredOutput:
 
         for i, result in enumerate(results):
             assert result is not None, f"Result {i} is None for {model}"
+
+    @pytest.mark.parametrize("model", JSON_SCHEMA_MODELS)
+    def test_structured_output_json_schema_method_invoke(
+        self, model, account_id, api_token, ai_gateway
+    ):
+        """method='json_schema' should work for models that support json_object mode."""
+        if not account_id or not api_token:
+            pytest.skip("Missing CF_ACCOUNT_ID or CF_AI_API_TOKEN")
+
+        llm = create_llm(model, account_id, api_token, ai_gateway)
+        structured_llm = llm.with_structured_output(Data, method="json_schema")
+
+        result = structured_llm.invoke(
+            f"Extract announcements from this text:\n\n{self.SAMPLE_TEXT}"
+        )
+
+        print(f"\n[{model}] Structured Output json_schema (invoke):")
+        print(f"  Result type: {type(result)}")
+        print(f"  Result: {result}")
+
+        assert result is not None, f"Result is None for {model}"
+        assert isinstance(result, (dict, Data)), (
+            f"Unexpected type {type(result)} for {model}"
+        )
+
+        if isinstance(result, dict):
+            assert "announcements" in result, f"Missing 'announcements' key for {model}"
+        else:
+            assert hasattr(result, "announcements"), (
+                f"Missing 'announcements' attr for {model}"
+            )
 
 
 class TestToolCalling:
@@ -706,6 +750,7 @@ class TestReasoningContent:
         "@cf/openai/gpt-oss-120b",
         "@cf/openai/gpt-oss-20b",
         "@cf/moonshotai/kimi-k2.5",
+        "@cf/moonshotai/kimi-k2.6",
         "@cf/google/gemma-4-26b-a4b-it",
         "@cf/nvidia/nemotron-3-120b-a12b",
     ]
@@ -927,6 +972,48 @@ class TestMultiModal:
             pytest.skip(
                 f"Model {model} does not support multi-modal: {error_msg[:100]}"
             )
+
+
+# MARK: - Vision Model Regression Tests
+
+
+class TestVisionModels:
+    """Regression tests for confirmed vision-capable models.
+
+    Unlike TestMultiModal (which skips failures), these tests assert that
+    VISION_MODELS must successfully process image input. A failure here means
+    vision support regressed for a model we know should work.
+    """
+
+    @pytest.mark.parametrize("model", VISION_MODELS)
+    def test_vision_invoke(self, model, account_id, api_token, ai_gateway):
+        """Vision models must return a non-empty response for image input."""
+        if not account_id or not api_token:
+            pytest.skip("Missing CF_ACCOUNT_ID or CF_AI_API_TOKEN")
+
+        llm = create_llm(model, account_id, api_token, ai_gateway)
+        image_b64 = create_test_image_base64()
+
+        message = HumanMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": "Describe this image in one sentence. What color is it?",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{image_b64}"},
+                },
+            ]
+        )
+
+        result = llm.invoke([message])
+        text = get_text_content(result.content)
+
+        print(f"\n[{model}] Vision invoke:")
+        print(f"  Response: {text[:200]}")
+
+        assert len(text) > 0, f"Expected non-empty vision response from {model}"
 
 
 if __name__ == "__main__":

--- a/libs/langchain-cloudflare/tests/unit_tests/test_chat_models.py
+++ b/libs/langchain-cloudflare/tests/unit_tests/test_chat_models.py
@@ -1,6 +1,6 @@
 """Test CloudflareWorkersAI Chat API wrapper."""
 
-from typing import Any, Dict, List, Type
+from typing import Any, Dict, List, Optional, Type
 
 import pytest
 from langchain_core.language_models import BaseChatModel
@@ -11,7 +11,10 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
+from langchain_core.prompt_values import ChatPromptValueConcrete
+from langchain_core.runnables import RunnableLambda, RunnableSequence
 from langchain_tests.unit_tests import ChatModelUnitTests
+from pydantic import BaseModel as PydanticBaseModel
 
 from langchain_cloudflare.chat_models import (
     ChatCloudflareWorkersAI,
@@ -372,6 +375,41 @@ class TestReasoningContent:
         assert msg.tool_calls[0]["name"] == "get_stock_price"
         assert msg.tool_calls[0]["args"] == {"ticker": "AAPL"}
 
+    def test_reasoning_content_with_tool_calls_and_dict_content(self):
+        """Dict content should be normalized before creating content blocks."""
+        llm = self._create_llm("@cf/openai/gpt-oss-120b")
+        response = {
+            "result": {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": {"announcements": []},
+                            "reasoning_content": "Need to check the schema.",
+                            "tool_calls": [
+                                {
+                                    "id": "call_123",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"city": "SF"}',
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                ]
+            }
+        }
+
+        result = llm._create_chat_result(response)
+        msg = result.generations[0].message
+
+        assert isinstance(msg.content, list)
+        text_blocks = [b for b in msg.content if b["type"] == "text"]
+        assert len(text_blocks) == 1
+        assert text_blocks[0]["text"] == '{"announcements": []}'
+
     def test_tool_calls_without_reasoning_content_unchanged(self):
         """Tool calls without reasoning_content produce empty string."""
         llm = self._create_llm("@cf/qwen/qwen3-30b-a3b-fp8")
@@ -723,3 +761,197 @@ class TestAIGatewayHeaders:
         )
         assert llm.client.headers["x-session-affinity"] == "session-456"
         assert llm.client.headers["cf-aig-request-timeout"] == "5000"
+
+
+# MARK: - with_structured_output Routing Tests
+
+
+class _Announcement(PydanticBaseModel):
+    title: str
+    summary: Optional[str] = None
+
+
+def _make_llm(model: str) -> ChatCloudflareWorkersAI:
+    return ChatCloudflareWorkersAI(
+        account_id="test_account",
+        api_token="test_token",
+        model=model,
+    )
+
+
+class TestWithStructuredOutputRouting:
+    """Unit tests for with_structured_output method routing.
+
+    All tests inspect the returned Runnable pipeline without calling the API.
+    """
+
+    # MARK: - json_schema method
+
+    def test_json_schema_method_injects_schema_system_message(self):
+        """method='json_schema' should prepend a schema system message."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        assert isinstance(chain, RunnableSequence)
+        # First step must be the schema-injection lambda
+        assert isinstance(chain.first, RunnableLambda)
+
+        # Invoke the lambda with a plain string and confirm schema is injected
+        result = chain.first.invoke("tell me something")
+        assert isinstance(result, list)
+        assert isinstance(result[0], SystemMessage)
+        assert "title" in result[0].content
+
+    def test_json_schema_method_sets_json_object_response_format(self):
+        """method='json_schema' on llama should bind response_format=json_object."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        # pipeline is: RunnableLambda | bound_llm | output_parser
+        # bound_llm is chain.steps[1]
+        bound_llm = chain.steps[1]
+        assert bound_llm.kwargs.get("response_format") == {"type": "json_object"}
+
+    def test_json_schema_method_merges_existing_system_message(self):
+        """Schema system message should merge with an existing system message."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+        inject = chain.first.func
+
+        messages = [SystemMessage(content="Be concise."), HumanMessage(content="hi")]
+        result = inject(messages)
+
+        assert isinstance(result[0], SystemMessage)
+        assert "Be concise." in result[0].content
+        assert "title" in result[0].content
+
+    def test_json_schema_method_injects_schema_for_chat_prompt_value(self):
+        """method='json_schema' should also rewrite prompt-value inputs."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        prompt_value = ChatPromptValueConcrete(
+            messages=[HumanMessage(content="tell me something")]
+        )
+        result = chain.first.invoke(prompt_value)
+
+        assert isinstance(result, list)
+        assert isinstance(result[0], SystemMessage)
+        assert "title" in result[0].content
+
+    def test_json_schema_method_merges_system_message_for_chat_prompt_value(self):
+        """Prompt-value inputs should preserve existing system instructions."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+        inject = chain.first.func
+
+        prompt_value = ChatPromptValueConcrete(
+            messages=[SystemMessage(content="Be concise."), HumanMessage(content="hi")]
+        )
+        result = inject(prompt_value)
+
+        assert isinstance(result, list)
+        assert isinstance(result[0], SystemMessage)
+        assert "Be concise." in result[0].content
+        assert "title" in result[0].content
+
+    def test_json_schema_method_works_on_gemma(self):
+        """Explicit method='json_schema' on Gemma should follow same path."""
+        llm = _make_llm("@cf/google/gemma-4-26b-a4b-it")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        assert isinstance(chain.first, RunnableLambda)
+        bound_llm = chain.steps[1]
+        assert bound_llm.kwargs.get("response_format") == {"type": "json_object"}
+
+    # MARK: - Gemma auto-routing
+
+    def test_gemma_function_calling_auto_routes_to_json_schema(self):
+        """Gemma with method='function_calling' should auto-route to json_schema."""
+        llm = _make_llm("@cf/google/gemma-4-26b-a4b-it")
+        chain = llm.with_structured_output(_Announcement)
+
+        # Same pipeline shape as json_schema: starts with injection lambda
+        assert isinstance(chain.first, RunnableLambda)
+        bound_llm = chain.steps[1]
+        assert bound_llm.kwargs.get("response_format") == {"type": "json_object"}
+
+    # MARK: - function_calling method (non-Gemma)
+
+    def test_function_calling_on_llama_uses_tool_calling(self):
+        """Default method='function_calling' on llama should NOT inject schema."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement)
+
+        # Pipeline is: bound_llm | output_parser — no injection lambda
+        assert not isinstance(chain.first, RunnableLambda)
+
+    def test_function_calling_raises_without_schema(self):
+        """method='function_calling' with schema=None should raise ValueError."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        with pytest.raises(ValueError, match="schema must be specified"):
+            llm.with_structured_output(None, method="function_calling")
+
+    # MARK: - json_mode method
+
+    def test_json_mode_sets_json_object_without_injection(self):
+        """method='json_mode' should set json_object but NOT inject a schema message."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        chain = llm.with_structured_output(_Announcement, method="json_mode")
+
+        # Pipeline is: bound_llm | output_parser — no injection lambda
+        assert not isinstance(chain.first, RunnableLambda)
+        assert chain.first.kwargs.get("response_format") == {"type": "json_object"}
+
+    # MARK: - Mistral guided_json mode
+
+    def test_mistral_json_schema_uses_json_object_with_injection(self):
+        """method='json_schema' on Mistral uses json_object + system message injection.
+
+        Mistral's Workers AI doesn't support complex schemas in guided_json, so we
+        fall back to json_object: constrain to valid JSON and inject the schema via
+        a system message prompt.
+        """
+        llm = _make_llm("@cf/mistralai/mistral-small-3.1-24b-instruct")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        # json_object path: starts with injection lambda (same as llama/gemma)
+        assert isinstance(chain.first, RunnableLambda)
+        bound_llm = chain.steps[1]
+        assert bound_llm.kwargs.get("response_format") == {"type": "json_object"}
+
+    def test_mistral_auto_routing_uses_tool_calling(self):
+        """Mistral with method='function_calling' should still use tool calling."""
+        llm = _make_llm("@cf/mistralai/mistral-small-3.1-24b-instruct")
+        chain = llm.with_structured_output(_Announcement)
+
+        assert not isinstance(chain.first, RunnableLambda)
+        assert "guided_json" not in chain.first.kwargs
+
+    # MARK: - gpt-oss json_schema_rf mode
+
+    def test_gpt_oss_json_schema_uses_json_schema_rf(self):
+        """method='json_schema' on gpt-oss should bind response_format=json_schema."""
+        llm = _make_llm("@cf/openai/gpt-oss-120b")
+        chain = llm.with_structured_output(_Announcement, method="json_schema")
+
+        assert not isinstance(chain.first, RunnableLambda)
+        rf = chain.first.kwargs.get("response_format", {})
+        assert rf.get("type") == "json_schema"
+        assert "title" in rf.get("json_schema", {})
+
+    def test_gpt_oss_auto_routing_uses_tool_calling(self):
+        """gpt-oss with default method='function_calling' should use tool calling."""
+        llm = _make_llm("@cf/openai/gpt-oss-120b")
+        chain = llm.with_structured_output(_Announcement)
+
+        assert not isinstance(chain.first, RunnableLambda)
+        assert "response_format" not in chain.first.kwargs
+
+    # MARK: - invalid method
+
+    def test_invalid_method_raises(self):
+        """Unknown method value should raise ValueError."""
+        llm = _make_llm("@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+        with pytest.raises(ValueError, match="Unrecognized method argument"):
+            llm.with_structured_output(_Announcement, method="bad_method")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- add `@cf/moonshotai/kimi-k2.6` to the tested model matrices and Worker example supported-model list
- harden structured output handling by making `method="json_schema"` a first-class option, fixing prompt-value schema injection, and normalizing dict-shaped model responses before constructing `AIMessage` content
- remove the older llama vision variants from general test coverage and keep the integration model lists aligned with the current supported set
- harden Vectorize readiness and namespace search tests for eventual consistency
- make Worker test startup reliable on local machines by using non-interactive Wrangler startup and preferring a modern `~/.nvm` Node runtime when the system `node` is too old for Wrangler 4
- bump `langchain-cloudflare` to `0.3.4` and update the changelog

## Test plan

- [x] `cd libs/langchain-cloudflare && make test`
- [x] `cd libs/langchain-cloudflare && set -a && source ../../.env && set +a && uv run pytest tests/integration_tests/test_workersai_models.py -v -s`
- [x] `cd libs/langchain-cloudflare && set -a && source ../../.env && set +a && uv run pytest tests/integration_tests/test_worker_integration.py -v -s`
- [x] `cd libs/langchain-cloudflare && make lint`
- [x] `pre-commit run --all-files`

## Validation notes

- `make test`: `101 passed, 2 skipped`
- Full Worker integration file: `145 passed, 6 skipped, 4 failed`
- The remaining Worker failures were not K2.6-specific:
  - `TestWorkerChat::test_chat_batch[@cf/mistralai/mistral-small-3.1-24b-instruct]`
  - `TestWorkerStructuredOutputBatch::test_structured_output_batch[@cf/openai/gpt-oss-20b]`
  - `TestWorkerMultiModal::test_multi_modal_image[@cf/mistralai/mistral-small-3.1-24b-instruct]`
  - `TestWorkerSessionAffinity::test_session_affinity_basic`
- During one long REST full-file run, `test_structured_output_json_schema_method_invoke[@cf/moonshotai/kimi-k2.6]` failed once, but the isolated rerun passed immediately, so it appears flaky rather than a deterministic K2.6 capability gap.
