### PR TITLE
[codex] fix Worker create_agent vendoring

### DIFF
--- a/libs/langchain-cloudflare/examples/workers/README.md
+++ b/libs/langchain-cloudflare/examples/workers/README.md
@@ -8,7 +8,7 @@ This example demonstrates how to use `langchain-cloudflare` with Cloudflare Pyth
 - Structured output with Pydantic models
 - Tool calling
 - Multi-turn conversations
-- `create_agent` pattern (requires langchain>=0.3.0)
+- `create_agent` pattern (requires langchain>=1.0.0)
 - Vectorize operations (insert, search, delete)
 - D1 database operations
 

--- a/libs/langchain-cloudflare/examples/workers/pyproject.toml
+++ b/libs/langchain-cloudflare/examples/workers/pyproject.toml
@@ -7,8 +7,9 @@ requires-python = ">=3.12"
 dependencies = [
     "webtypy>=0.1.7",
     "langchain-cloudflare @ file:////Users/collierking/Desktop/github/langchain-cloudflare/libs/langchain-cloudflare",
+    # Keep pywrangler sync on the latest Pyodide-compatible 0.3.x core.
+    # scripts/setup_pyodide_deps.sh replaces this with LangChain 1.x wheels.
     "langchain-core>=0.3.81,<1.0.0",
-    "langchain>=0.3.0,<1.0.0",
     "sqlalchemy-cloudflare-d1 @ file:////Users/collierking/Desktop/github/sqlalchemy-cloudflare-d1",
     # NOTE: Do NOT include pydantic - use Pyodide's built-in version
     # pydantic_core requires compiled Rust binaries that aren't available for WebAssembly

--- a/libs/langchain-cloudflare/examples/workers/scripts/setup_pyodide_deps.sh
+++ b/libs/langchain-cloudflare/examples/workers/scripts/setup_pyodide_deps.sh
@@ -13,8 +13,9 @@
 # - pywrangler sync fails when it encounters these missing wheels
 #
 # Solution:
-# - Install langchain-core>=1.0.0 via pywrangler (pure Python, has wheels)
-# - Manually extract langchain, langgraph, langgraph_sdk wheels
+# - Install a Pyodide-compatible langchain-core 0.3.x via pywrangler
+# - Replace it by manually extracting langchain-core 1.x plus langchain,
+#   langgraph, and langgraph_sdk wheels
 # - Use pure Python stubs for xxhash and ormsgpack
 
 set -e
@@ -27,8 +28,9 @@ TEMP_DIR="$PROJECT_DIR/.wheels_temp"
 
 # MARK: - Configuration
 
-# Wheel versions to download
-# NOTE: langchain 1.0.0 actually needs langchain-core 1.1.0 for all imports to work
+# Wheel versions to download.
+# This stack is known to keep create_agent available in Python Workers without
+# pulling newer native dependencies that do not have Pyodide wheels.
 LANGCHAIN_VERSION="1.0.0"
 LANGCHAIN_CORE_VERSION="1.1.0"
 LANGGRAPH_VERSION="1.0.0"
@@ -107,6 +109,8 @@ rm -rf "$PYTHON_MODULES/langchain_core" "$PYTHON_MODULES/langchain_core-"*.dist-
 rm -rf "$PYTHON_MODULES/langgraph" "$PYTHON_MODULES/langgraph-"*.dist-info 2>/dev/null || true
 rm -rf "$PYTHON_MODULES/langgraph_sdk" "$PYTHON_MODULES/langgraph_sdk-"*.dist-info 2>/dev/null || true
 rm -rf "$PYTHON_MODULES/langgraph_checkpoint" "$PYTHON_MODULES/langgraph_checkpoint-"*.dist-info 2>/dev/null || true
+rm -rf "$PYTHON_MODULES/langchain_protocol" "$PYTHON_MODULES/langchain_protocol-"*.dist-info 2>/dev/null || true
+rm -rf "$PYTHON_MODULES/langgraph_prebuilt" "$PYTHON_MODULES/langgraph_prebuilt-"*.dist-info 2>/dev/null || true
 
 download_and_extract_wheel "langchain" "$LANGCHAIN_VERSION"
 download_and_extract_wheel "langchain-core" "$LANGCHAIN_CORE_VERSION"
@@ -131,6 +135,9 @@ echo "Step 3: Building and copying stubs..."
 # Remove old stub copies
 rm -rf "$PYTHON_MODULES/xxhash" 2>/dev/null || true
 rm -rf "$PYTHON_MODULES/ormsgpack" 2>/dev/null || true
+rm -rf "$PYTHON_MODULES/orjson" "$PYTHON_MODULES/orjson-"*.dist-info 2>/dev/null || true
+rm -rf "$PYTHON_MODULES/uuid_utils" "$PYTHON_MODULES/uuid_utils-"*.dist-info 2>/dev/null || true
+rm -rf "$PYTHON_MODULES/websockets" "$PYTHON_MODULES/websockets-"*.dist-info 2>/dev/null || true
 
 build_stub "xxhash"
 build_stub "ormsgpack"

--- a/libs/langchain-cloudflare/examples/workers/src/entry.py
+++ b/libs/langchain-cloudflare/examples/workers/src/entry.py
@@ -677,7 +677,7 @@ Return JSON with an "announcements" array. Each announcement should have:
         """Handle create_agent with structured output."""
         if not CREATE_AGENT_AVAILABLE:
             return Response.json(
-                {"error": "create_agent is not available. Install langchain>=0.3.0"},
+                {"error": "create_agent is not available. Install langchain>=1.0.0"},
                 status=501,
             )
 
@@ -815,7 +815,7 @@ Return JSON with an "announcements" array. Each announcement should have:
         """Handle create_agent with tools."""
         if not CREATE_AGENT_AVAILABLE:
             return Response.json(
-                {"error": "create_agent is not available. Install langchain>=0.3.0"},
+                {"error": "create_agent is not available. Install langchain>=1.0.0"},
                 status=501,
             )
 

--- a/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_worker_integration.py
@@ -302,12 +302,7 @@ class TestWorkerMultiTurn:
 
 
 class TestWorkerAgentStructuredOutput:
-    """Test create_agent with structured output endpoint.
-
-    Note: These tests will fail with 501 if create_agent is not available in the
-    Pyodide environment due to the uuid-utils dependency in langsmith.
-    See .claude/create_agent_pyodide_issue.md for details.
-    """
+    """Test create_agent with structured output endpoint."""
 
     @pytest.mark.parametrize("model", MODELS)
     def test_agent_structured_output(self, dev_server, model):
@@ -318,9 +313,6 @@ class TestWorkerAgentStructuredOutput:
             json={"text": "Apple Inc announced record Q4 earnings.", "model": model},
             headers={"Content-Type": "application/json"},
         )
-
-        if response.status_code == 501:
-            pytest.skip("create_agent unavailable (uuid-utils not in Pyodide)")
 
         assert response.status_code == 200, (
             f"Expected 200, got {response.status_code}. Response: {response.text}"
@@ -352,9 +344,6 @@ class TestWorkerAgentStructuredJsonSchema:
             headers={"Content-Type": "application/json"},
         )
 
-        if response.status_code == 501:
-            pytest.skip("create_agent or ToolStrategy unavailable in Pyodide")
-
         assert response.status_code == 200, (
             f"Expected 200, got {response.status_code}. Response: {response.text}"
         )
@@ -369,12 +358,7 @@ class TestWorkerAgentStructuredJsonSchema:
 
 
 class TestWorkerAgentTools:
-    """Test create_agent with tools endpoint.
-
-    Note: These tests will fail with 501 if create_agent is not available in the
-    Pyodide environment due to the uuid-utils dependency in langsmith.
-    See .claude/create_agent_pyodide_issue.md for details.
-    """
+    """Test create_agent with tools endpoint."""
 
     @pytest.mark.parametrize("model", MODELS)
     def test_agent_tools(self, dev_server, model):
@@ -385,9 +369,6 @@ class TestWorkerAgentTools:
             json={"message": "What is the weather in San Francisco?", "model": model},
             headers={"Content-Type": "application/json"},
         )
-
-        if response.status_code == 501:
-            pytest.skip("create_agent unavailable (uuid-utils not in Pyodide)")
 
         assert response.status_code == 200, (
             f"Expected 200, got {response.status_code}. Response: {response.text}"


### PR DESCRIPTION
## Summary

Fixes the Worker example dependency layout after PR #44 was already merged.

- Removes the direct `langchain` dependency from `examples/workers/pyproject.toml` so `pywrangler sync` only resolves Pyodide-compatible dependencies.
- Keeps the known-working Worker `create_agent` stack in `scripts/setup_pyodide_deps.sh`: `langchain==1.0.0`, `langchain-core==1.1.0`, `langgraph==1.0.0`, `langgraph-sdk==0.3.1`, and `langgraph-checkpoint==2.1.0`.
- Cleans stale newer 1.3.x-only packages from `python_modules` during setup so local runs cannot pass due to leftovers.
- Makes Worker `create_agent` integration tests fail on `501` instead of skipping when `create_agent` is unavailable.

## Why

A separate Dependabot security-update job on `main` failed because the Worker example declared broad direct `langchain>=0.3.0,<1.0.0` without a lockfile/pinned installed version.

The correct Worker fix is not to move `pyproject.toml` to newer `langchain>=1.3.x`: that breaks `pywrangler sync` and Pyodide because newer transitive dependencies pull native packages without Pyodide wheels. The Worker example already uses a manual vendoring script for this reason, so this makes that split explicit and keeps `create_agent` supported.

## Validation

- `cd libs/langchain-cloudflare/examples/workers && env PATH="$HOME/.nvm/versions/node/v22.17.1/bin:$PATH" uv run pywrangler sync --force` - passed
- `cd libs/langchain-cloudflare/examples/workers && env PATH="$HOME/.nvm/versions/node/v22.17.1/bin:$PATH" ./scripts/setup_pyodide_deps.sh` - passed
- `cd libs/langchain-cloudflare && set -a && source ../../.env && set +a && env PATH="$HOME/.nvm/versions/node/v22.17.1/bin:$PATH" uv run pytest 'tests/integration_tests/test_worker_integration.py::TestWorkerAgentTools::test_agent_tools[@cf/qwen/qwen3-30b-a3b-fp8]' 'tests/integration_tests/test_worker_integration.py::TestWorkerAgentStructuredOutput::test_agent_structured_output[@cf/qwen/qwen3-30b-a3b-fp8]' 'tests/integration_tests/test_worker_integration.py::TestWorkerAgentStructuredJsonSchema::test_agent_structured_json_schema[@cf/qwen/qwen3-30b-a3b-fp8]' -v -s` - 3 passed
- `cd libs/langchain-cloudflare && make lint` - passed
- `cd libs/langchain-cloudflare && make test` - 110 passed, 2 skipped
- `pre-commit run --all-files` - passed

Note: representative Llama `agent-tools` and JSON-schema agent paths passed, while the Pydantic structured agent path hit an upstream Workers AI `504 Gateway Time-out`. The same Pydantic path passed immediately on Qwen.
