### PR TITLE
Add AI Search retriever notebook

### DIFF
--- a/docs/ai_search.ipynb
+++ b/docs/ai_search.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: CloudflareAISearchRetriever\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cloudflare AI Search\n",
+    "\n",
+    "This notebook uses the official Cloudflare Python SDK to create and populate an AI Search instance, then queries it through the LangChain `CloudflareAISearchRetriever` integration."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the Cloudflare Python SDK and the LangChain Cloudflare integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU cloudflare langchain-cloudflare python-dotenv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Credentials\n",
+    "\n",
+    "Create a Cloudflare API token with **AI Search:Edit** and **AI Search:Run** permissions. Set the following values in your environment or `.env` file:\n",
+    "\n",
+    "- `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`, matching the official Cloudflare SDK conventions; or\n",
+    "- `CF_ACCOUNT_ID` and `CF_AI_SEARCH_API_TOKEN`, matching the `langchain-cloudflare` conventions.\n",
+    "\n",
+    "The optional `CF_AI_SEARCH_NAMESPACE` value defaults to `default`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(\".env\")\n",
+    "\n",
+    "account_id = os.getenv(\"CLOUDFLARE_ACCOUNT_ID\") or os.getenv(\"CF_ACCOUNT_ID\")\n",
+    "api_token = (\n",
+    "    os.getenv(\"CF_AI_SEARCH_API_TOKEN\")\n",
+    "    or os.getenv(\"CLOUDFLARE_API_TOKEN\")\n",
+    "    or os.getenv(\"CF_API_TOKEN\")\n",
+    ")\n",
+    "namespace = os.getenv(\"CF_AI_SEARCH_NAMESPACE\", \"default\")\n",
+    "\n",
+    "if not account_id or not api_token:\n",
+    "    raise ValueError(\"Set a Cloudflare account ID and AI Search API token\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Use a unique instance name and query marker so this run cannot collide with another notebook session."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import uuid\n",
+    "\n",
+    "from cloudflare import Cloudflare\n",
+    "from langchain_cloudflare import CloudflareAISearchRetriever\n",
+    "\n",
+    "cloudflare = Cloudflare(api_token=api_token)\n",
+    "instance_name = f\"langchain-ai-search-{uuid.uuid4().hex[:8]}\"\n",
+    "query_marker = f\"langchain-ai-search-notebook-{uuid.uuid4().hex}\"\n",
+    "\n",
+    "instance_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an AI Search instance\n",
+    "\n",
+    "The `default` namespace exists automatically. Because this instance does not specify another data source, AI Search provisions built-in storage for direct file uploads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instance = cloudflare.aisearch.namespaces.instances.create(\n",
+    "    name=namespace,\n",
+    "    account_id=account_id,\n",
+    "    id=instance_name,\n",
+    ")\n",
+    "\n",
+    "instance.id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload content\n",
+    "\n",
+    "Upload a Markdown document to the instance's built-in storage. The upload returns without waiting for indexing, and the next cell polls the item status with a bounded timeout."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content = \"\\n\".join(\n",
+    "    [\n",
+    "        \"# LangChain Cloudflare AI Search notebook\",\n",
+    "        \"\",\n",
+    "        f\"{query_marker} validates AI Search retrieval through LangChain.\",\n",
+    "        \"Cloudflare AI Search indexes uploaded files for natural language search.\",\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "item = cloudflare.aisearch.namespaces.instances.items.upload(\n",
+    "    id=instance_name,\n",
+    "    account_id=account_id,\n",
+    "    name=namespace,\n",
+    "    file={\n",
+    "        \"file\": (\"langchain-guide.md\", content.encode(), \"text/markdown\"),\n",
+    "        \"wait_for_completion\": False,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "item.status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deadline = time.monotonic() + 240\n",
+    "\n",
+    "while item.status in {\"queued\", \"running\"} and time.monotonic() < deadline:\n",
+    "    time.sleep(3)\n",
+    "    item = cloudflare.aisearch.namespaces.instances.items.get(\n",
+    "        item.id,\n",
+    "        id=instance_name,\n",
+    "        account_id=account_id,\n",
+    "        name=namespace,\n",
+    "    )\n",
+    "\n",
+    "if item.status != \"completed\":\n",
+    "    raise RuntimeError(f\"Indexing did not complete: {item.status}: {item.error}\")\n",
+    "\n",
+    "item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Search with the Cloudflare SDK\n",
+    "\n",
+    "First, issue a raw AI Search query through the official SDK. The response contains the matching indexed chunks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = cloudflare.aisearch.namespaces.instances.search(\n",
+    "    id=instance_name,\n",
+    "    account_id=account_id,\n",
+    "    name=namespace,\n",
+    "    query=query_marker,\n",
+    ")\n",
+    "\n",
+    "[(chunk.text, chunk.score) for chunk in results.chunks]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve with LangChain\n",
+    "\n",
+    "`CloudflareAISearchRetriever` converts AI Search chunks into LangChain `Document` objects. It can be used directly in chains, agents, and retriever tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retriever = CloudflareAISearchRetriever(\n",
+    "    account_id=account_id,\n",
+    "    api_token=api_token,\n",
+    "    namespace=namespace,\n",
+    "    instance_name=instance_name,\n",
+    "    k=3,\n",
+    "    rewrite_query=False,\n",
+    "    reranking=False,\n",
+    ")\n",
+    "\n",
+    "documents = retriever.invoke(query_marker)\n",
+    "[(document.page_content, document.metadata) for document in documents]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Python Workers\n",
+    "\n",
+    "The Cloudflare Python SDK can run in Python Workers through its asynchronous client:\n",
+    "\n",
+    "```python\n",
+    "from cloudflare import AsyncCloudflare\n",
+    "\n",
+    "client = AsyncCloudflare(api_token=env.CLOUDFLARE_API_TOKEN)\n",
+    "results = await client.aisearch.namespaces.instances.search(\n",
+    "    id=\"my-instance\",\n",
+    "    account_id=env.CLOUDFLARE_ACCOUNT_ID,\n",
+    "    name=\"default\",\n",
+    "    query=\"How does AI Search work?\",\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "For retrieval inside a Worker, a dedicated AI Search binding avoids storing an API token and making an outbound REST request:\n",
+    "\n",
+    "```python\n",
+    "retriever = CloudflareAISearchRetriever(binding=env.MY_SEARCH)\n",
+    "documents = await retriever.ainvoke(\"How does AI Search work?\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Delete only the item and instance created by this notebook run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cloudflare.aisearch.namespaces.instances.items.delete(\n",
+    "    item.id,\n",
+    "    id=instance_name,\n",
+    "    account_id=account_id,\n",
+    "    name=namespace,\n",
+    ")\n",
+    "cloudflare.aisearch.namespaces.instances.delete(\n",
+    "    instance_name,\n",
+    "    account_id=account_id,\n",
+    "    name=namespace,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "- [Cloudflare AI Search Python SDK guide](https://developers.cloudflare.com/ai-search/get-started/python/)\n",
+    "- [Cloudflare Python SDK](https://developers.cloudflare.com/api/python/)\n",
+    "- [Cloudflare AI Search Workers binding](https://developers.cloudflare.com/ai-search/api/instances/workers-binding/)\n",
+    "- [LangChain retriever concepts](https://python.langchain.com/docs/concepts/retrievers/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cc-langchain-G_cWTCcf-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## What changed

- Adds `docs/ai_search.ipynb` using the official Cloudflare Python SDK for AI Search instance creation, file upload, indexing status, raw search, and cleanup.
- Demonstrates `CloudflareAISearchRetriever` over the populated instance and shows both `AsyncCloudflare` and native AI Search binding usage in Python Workers.
- Uses unique resource names and deletes only the item and instance created by the notebook run.
- Uses a nonblocking upload followed by bounded polling so long indexing jobs do not exceed the SDK request timeout.

## Why

The official Cloudflare Python SDK is the canonical Python administration client for AI Search. This keeps `langchain-cloudflare` focused on its LangChain retriever integration instead of introducing a second, partial REST administration client.

This is documentation-only and does not change package dependencies, versions, or runtime behavior.

## Validation

- `pre-commit run --all-files`
- `make lint`
- `make test` - 136 passed, 2 skipped
- Notebook JSON and Python code-cell syntax validation
- Live lifecycle with Cloudflare Python SDK 5.5.0: create, upload, index, SDK search, LangChain retrieval, item delete, and instance delete
