### PR TITLE
fix: sync CloudflareD1Saver.list() ignoring before and metadata filters

### DIFF
--- a/libs/langgraph-checkpoint-cloudflare-d1/langgraph_checkpoint_cloudflare_d1/__init__.py
+++ b/libs/langgraph-checkpoint-cloudflare-d1/langgraph_checkpoint_cloudflare_d1/__init__.py
@@ -460,44 +460,13 @@ class CloudflareD1Saver(BaseCheckpointSaver[str]):
         Returns:
             Iterator[CheckpointTuple]: Iterator over checkpoint tuples.
         """
-        filter = filter or {}
-        thread_id = None
-
-        # Extract thread ID from config or filter
-        if (
-            config
-            and "configurable" in config
-            and "thread_id" in config["configurable"]
-        ):
-            thread_id = config["configurable"]["thread_id"]
-        elif filter and "thread_id" in filter:
-            thread_id = filter["thread_id"]
-
-        # Do not filter results - simply iterate and yield checkpoints
         with self.lock:
-            if not thread_id:
-                return
-
             self.setup()
 
-            # Determine what to filter by
-            filter_by = []
-            params = []
-
-            if filter:
-                # Support exact match filtering on thread_id and checkpoint_id
-                for key, value in filter.items():
-                    if key in ["thread_id", "checkpoint_id"]:
-                        filter_by.append(f"{key} = ?")
-                        params.append(value)
-                    else:
-                        # For complex filtering, would need metadata query support
-                        continue
-
-            filter_clause = f"WHERE {' AND '.join(filter_by)}" if filter_by else ""
+            where, params = search_where(config, filter, before)
             limit_clause = f"LIMIT {limit}" if limit else ""
 
-            query = f"SELECT * FROM checkpoints {filter_clause} ORDER BY checkpoint_id DESC {limit_clause}"
+            query = f"SELECT * FROM checkpoints {where} ORDER BY checkpoint_id DESC {limit_clause}"
 
             response = self._execute_query(query, params)
 

--- a/libs/langgraph-checkpoint-cloudflare-d1/langgraph_checkpoint_cloudflare_d1/utils.py
+++ b/libs/langgraph-checkpoint-cloudflare-d1/langgraph_checkpoint_cloudflare_d1/utils.py
@@ -51,14 +51,16 @@ def _metadata_predicate(
         """Return tuple of operator and value for WHERE clause predicate."""
         if query_value is None:
             return ("IS ?", None)
+        elif isinstance(query_value, bool):
+            # Must be checked before the int branch: bool is a subclass of int
+            # in Python, so `isinstance(True, int)` is also True.
+            return ("= ?", 1 if query_value else 0)
         elif (
             isinstance(query_value, str)
             or isinstance(query_value, int)
             or isinstance(query_value, float)
         ):
             return ("= ?", query_value)
-        elif isinstance(query_value, bool):
-            return ("= ?", 1 if query_value else 0)
         elif isinstance(query_value, dict) or isinstance(query_value, list):
             # query value for JSON object cannot have trailing space after separators (, :)
             # SQLite json_extract() returns JSON string without whitespace

--- a/libs/langgraph-checkpoint-cloudflare-d1/tests/unit_tests/test_list_filtering.py
+++ b/libs/langgraph-checkpoint-cloudflare-d1/tests/unit_tests/test_list_filtering.py
@@ -1,0 +1,51 @@
+"""Regression tests: sync list() must apply the same filtering as async alist().
+
+Before the fix, CloudflareD1Saver.list() built its own WHERE clause that only
+supported exact-match filtering on `thread_id`/`checkpoint_id` and silently
+dropped every other filter key plus the `before` argument entirely, unlike
+alist() (which correctly delegates to search_where()). A caller filtering by
+metadata, or paginating with `before`, got back unfiltered results with no
+error.
+"""
+
+from unittest.mock import patch
+
+from langgraph_checkpoint_cloudflare_d1 import CloudflareD1Saver
+from langgraph_checkpoint_cloudflare_d1.models import D1Response
+
+
+def _make_saver() -> CloudflareD1Saver:
+    saver = CloudflareD1Saver(
+        account_id="acct", database_id="db", api_token="token"
+    )
+    saver.is_setup = True  # skip the CREATE TABLE round-trip
+    return saver
+
+
+def test_list_passes_metadata_filter_into_the_query() -> None:
+    saver = _make_saver()
+    config = {"configurable": {"thread_id": "t1"}}
+
+    with patch.object(
+        saver, "_execute_query", return_value=D1Response(success=True, result=[])
+    ) as mock_execute:
+        list(saver.list(config, filter={"source": "loop"}))
+
+    query, params = mock_execute.call_args[0]
+    assert "json_extract" in query
+    assert "loop" in params
+
+
+def test_list_passes_before_into_the_query() -> None:
+    saver = _make_saver()
+    config = {"configurable": {"thread_id": "t1"}}
+    before = {"configurable": {"thread_id": "t1", "checkpoint_id": "c9"}}
+
+    with patch.object(
+        saver, "_execute_query", return_value=D1Response(success=True, result=[])
+    ) as mock_execute:
+        list(saver.list(config, before=before))
+
+    query, params = mock_execute.call_args[0]
+    assert "checkpoint_id < ?" in query
+    assert "c9" in params

--- a/libs/langgraph-checkpoint-cloudflare-d1/tests/unit_tests/test_utils.py
+++ b/libs/langgraph-checkpoint-cloudflare-d1/tests/unit_tests/test_utils.py
@@ -1,0 +1,37 @@
+"""Unit tests for langgraph_checkpoint_cloudflare_d1.utils."""
+
+from langgraph_checkpoint_cloudflare_d1.utils import _metadata_predicate, search_where
+
+
+def test_metadata_predicate_bool_true_encodes_as_one() -> None:
+    # bool is a subclass of int in Python, so the int/str/float branch would
+    # silently swallow a bool value unless it is checked first. A raw Python
+    # `True`/`False` passed through as the SQL parameter would not match
+    # SQLite's json_extract(), which returns integer 1/0 for JSON booleans.
+    predicates, values = _metadata_predicate({"completed": True})
+    assert values == [1]
+    assert predicates == ["json_extract(CAST(metadata AS TEXT), '$.completed') = ?"]
+
+
+def test_metadata_predicate_bool_false_encodes_as_zero() -> None:
+    predicates, values = _metadata_predicate({"completed": False})
+    assert values == [0]
+
+
+def test_metadata_predicate_int_still_passes_through() -> None:
+    predicates, values = _metadata_predicate({"step": 3})
+    assert values == [3]
+
+
+def test_search_where_applies_metadata_filter() -> None:
+    where, params = search_where(None, {"source": "loop"})
+    assert "json_extract" in where
+    assert params == ["loop"]
+
+
+def test_search_where_applies_before() -> None:
+    config = {"configurable": {"thread_id": "t1"}}
+    before = {"configurable": {"thread_id": "t1", "checkpoint_id": "c5"}}
+    where, params = search_where(config, None, before)
+    assert "checkpoint_id < ?" in where
+    assert "c5" in params


### PR DESCRIPTION
`CloudflareD1Saver.list()` (sync) built its own ad-hoc WHERE clause that only supported exact-match filtering on `thread_id`/`checkpoint_id`, silently dropping any other filter key, and never referenced the `before` parameter at all. `alist()` (async) correctly delegates to `search_where()` for the same method signature. A caller filtering checkpoints by metadata, or paginating with `before`, silently got back every checkpoint for the thread instead of the filtered subset, with no error.

Fixed `list()` to use `search_where()`, matching `alist()`'s already-correct implementation.

While verifying, also found a real bug in `search_where()`'s metadata predicate builder (`_where_value` in `utils.py`): the `bool` branch was checked *after* the `int` branch, so it was unreachable — `bool` is a subclass of `int` in Python (`isinstance(True, int)` is `True`). A boolean filter value was passed through as a raw Python `True`/`False` instead of being converted to `1`/`0`, which is what SQLite's `json_extract()` actually returns for a JSON boolean. Fixed by checking `bool` first.

Added tests for both: `test_utils.py` covers the bool-encoding fix directly against `search_where`/`_metadata_predicate`; `test_list_filtering.py` mocks `_execute_query` to confirm `list()` now builds the same WHERE clause/params that `search_where()` produces for a metadata filter and for `before`. Confirmed both new `list()` tests fail on unpatched code (`git stash`) and pass after the fix. `ruff check` and `mypy` both clean.
