### PR TITLE
fix(langmem-vectorize): search() crashes on empty namespace prefix with no query

### DIFF
--- a/libs/langmem-cloudflare-vectorize/langmem_cloudflare_vectorize/langmem_vectorize_basestore.py
+++ b/libs/langmem-cloudflare-vectorize/langmem_cloudflare_vectorize/langmem_vectorize_basestore.py
@@ -433,14 +433,17 @@ class CloudflareVectorizeBaseStore(BaseStore):
                 )
                 docs_and_scores = [(doc, score) for doc, score in docs_with_scores]
             else:
-                # Generate search data for vectorize
-                if namespace_prefix_str:
-                    docs_with_scores = self.vectorstore.similarity_search_with_score(
-                        query=" ",  # Dummy query to get all results
-                        k=limit + offset,
-                        md_filter=search_filter,
-                    )
-                    docs_and_scores = [(doc, score) for doc, score in docs_with_scores]
+                # No query: fetch candidates with a dummy query and rely on the
+                # namespace-prefix filtering below. An empty namespace_prefix_str
+                # is a valid "search everything" request (every namespace starts
+                # with ""), so this must run regardless of whether a prefix was
+                # given -- not just when namespace_prefix_str is truthy.
+                docs_with_scores = self.vectorstore.similarity_search_with_score(
+                    query=" ",  # Dummy query to get all results
+                    k=limit + offset,
+                    md_filter=search_filter,
+                )
+                docs_and_scores = [(doc, score) for doc, score in docs_with_scores]
 
             # Filter by namespace prefix and apply pagination
             results = []

--- a/libs/langmem-cloudflare-vectorize/tests/unit_tests/test_search_empty_namespace.py
+++ b/libs/langmem-cloudflare-vectorize/tests/unit_tests/test_search_empty_namespace.py
@@ -1,0 +1,65 @@
+"""Regression test: search() must not crash on an empty namespace_prefix with no query.
+
+Before the fix, `store.search(())` (list everything, no query -- a documented
+valid LangGraph BaseStore usage) raised UnboundLocalError because
+`docs_and_scores` was only assigned when `namespace_prefix_str` was truthy.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from langmem_cloudflare_vectorize import CloudflareVectorizeBaseStore
+
+
+@dataclass
+class FakeDocument:
+    page_content: str
+    metadata: dict[str, Any]
+
+
+class FakeVectorstore:
+    def __init__(self, docs_with_scores: list[tuple[FakeDocument, float]]):
+        self._docs_with_scores = docs_with_scores
+        self.calls: list[dict[str, Any]] = []
+
+    def similarity_search_with_score(self, *, query, k, md_filter):
+        self.calls.append({"query": query, "k": k, "md_filter": md_filter})
+        return self._docs_with_scores
+
+
+def _make_store(vectorstore: FakeVectorstore) -> CloudflareVectorizeBaseStore:
+    store = CloudflareVectorizeBaseStore.__new__(CloudflareVectorizeBaseStore)
+    store.vectorstore = vectorstore
+    return store
+
+
+def _doc(namespace: str, key: str) -> FakeDocument:
+    return FakeDocument(
+        page_content="",
+        metadata={
+            "namespace": namespace,
+            "key": key,
+            "data": "{}",
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+        },
+    )
+
+
+def test_search_with_empty_namespace_prefix_and_no_query_does_not_crash() -> None:
+    vectorstore = FakeVectorstore([(_doc("a/b", "k1"), 0.9), (_doc("c", "k2"), 0.8)])
+    store = _make_store(vectorstore)
+
+    results = store.search(())
+
+    assert len(vectorstore.calls) == 1
+    assert {item.key for item in results} == {"k1", "k2"}
+
+
+def test_search_with_nonempty_namespace_prefix_and_no_query_still_works() -> None:
+    vectorstore = FakeVectorstore([(_doc("a/b", "k1"), 0.9), (_doc("c", "k2"), 0.8)])
+    store = _make_store(vectorstore)
+
+    results = store.search(("a",))
+
+    assert [item.key for item in results] == ["k1"]


### PR DESCRIPTION
`CloudflareVectorizeBaseStore.search()` only assigns `docs_and_scores` when `query` is truthy, or when `query` is falsy and `namespace_prefix_str` is truthy. If both are empty — `store.search(())`, listing everything with no query, a documented valid LangGraph `BaseStore` usage — neither branch runs, and the code falls through to `for doc, score in docs_and_scores:`, raising `UnboundLocalError`.

An empty namespace prefix is a valid "search everything" request (every namespace string starts with `""`), so the dummy-query fetch now runs unconditionally whenever no `query` is given, and the existing namespace-prefix filtering loop below handles the rest.

Added `tests/unit_tests/test_search_empty_namespace.py`. Confirmed the crash reproduces on unpatched code (`git stash`) with the exact `UnboundLocalError`, and passes after the fix. `ruff check` and `mypy` clean.
