### PR TITLE
fix(reranker): _process_response never actually sorts results by score

### DIFF
--- a/libs/langchain-cloudflare/langchain_cloudflare/rerankers.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/rerankers.py
@@ -210,6 +210,7 @@ class CloudflareWorkersAIReranker(BaseModel):
                 )
             )
 
+        results.sort(key=lambda r: r.score, reverse=True)
         return results
 
     @staticmethod

--- a/libs/langchain-cloudflare/tests/unit_tests/test_rerankers.py
+++ b/libs/langchain-cloudflare/tests/unit_tests/test_rerankers.py
@@ -66,3 +66,54 @@ class TestTokenValidation:
             ValueError, match=re.escape(str(TokenErrors.INSUFFICIENT_AI_TOKENS))
         ):
             CloudflareWorkersAIReranker(account_id="abc", api_token="")
+
+
+# MARK: - Response Ordering Tests
+class TestProcessResponseOrdering:
+    """_process_response's own docstring promises results sorted by score
+    (descending), but nothing in the implementation enforced that -- it just
+    appended results in whatever order the API response listed them.
+    """
+
+    def test_results_sorted_by_score_descending(self):
+        """A response with scores out of order must come back sorted."""
+        reranker = CloudflareWorkersAIReranker(
+            account_id="abc123",
+            api_token="valid-token",
+        )
+        documents = ["low relevance", "high relevance", "medium relevance"]
+        # Deliberately not in descending score order, matching a plausible
+        # raw API response order (e.g. original input order).
+        response_data = [
+            {"id": 0, "score": 0.1},
+            {"id": 1, "score": 0.9},
+            {"id": 2, "score": 0.5},
+        ]
+
+        results = reranker._process_response(
+            response_data, documents, [None, None, None], return_documents=False
+        )
+
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+        assert scores == [0.9, 0.5, 0.1]
+        assert [r.index for r in results] == [1, 2, 0]
+
+    def test_already_sorted_response_stays_sorted(self):
+        """Sanity check: a response already in descending order is unaffected."""
+        reranker = CloudflareWorkersAIReranker(
+            account_id="abc123",
+            api_token="valid-token",
+        )
+        documents = ["a", "b", "c"]
+        response_data = [
+            {"id": 1, "score": 0.9},
+            {"id": 2, "score": 0.5},
+            {"id": 0, "score": 0.1},
+        ]
+
+        results = reranker._process_response(
+            response_data, documents, [None, None, None], return_documents=False
+        )
+
+        assert [r.score for r in results] == [0.9, 0.5, 0.1]


### PR DESCRIPTION
Every docstring on `CloudflareWorkersAIReranker` (`rerank()`, `arerank()`, and `_process_response()` itself) promises results sorted by relevance score descending, but the implementation just appended results in whatever order the API response listed them — no `sort()` call anywhere, and nothing in the test suite exercised this.

Tested against the live Workers AI API directly: the default model (`@cf/baai/bge-reranker-base`) does already return results sorted by score, so this isn't causing wrong output for the default model today. But the code shouldn't depend on an undocumented assumption about API/model behavior — the sort is one line, and it's what the docstrings already promise regardless of what a given model happens to do.

Added the sort plus two tests (an out-of-order response and an already-sorted one). Full unit suite: 138 passed, 2 skipped, 0 regressions.