### PR TITLE
feat: add GLM 5.3 Flash support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+---
+codex_session_id: "01a0448b-978b-7992-84d8-dbecb9f8497c"
+repo: "cloudflare/langchain-cloudflare"
+branch: "feat/add-glm-5-3-flash"
+last_updated: "2026-08-27"
+---
+
 # Changelog
 
 All notable changes to the Langchain Cloudflare packages will be documented in this file.
@@ -7,6 +14,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## langchain-cloudflare
+
+### [0.3.9]
+
+#### Added
+
+- **`@cf/zai-org/glm-5.3-flash`**: Added to the tested and example-supported
+  model lists with reasoning content, function calling, structured output,
+  streaming, and vision support. The model has a 1,048,576-token context window
+  and requires the Workers Paid plan or prepaid AI Gateway credits.
+
+#### Changed
+
+- **Llama 3.3 live coverage removed**: Removed
+  `@cf/meta/llama-3.3-70b-instruct-fp8-fast` from the advertised example list
+  and recurring REST and Worker model matrices. Generic integration checks now
+  use current Qwen or Mistral models instead.
+
+---
 
 ### [0.3.8]
 

--- a/libs/langchain-cloudflare/examples/workers/src/entry.py
+++ b/libs/langchain-cloudflare/examples/workers/src/entry.py
@@ -36,12 +36,12 @@ from langchain_cloudflare.rerankers import CloudflareWorkersAIReranker
 
 # Supported Workers AI models for this example
 SUPPORTED_MODELS = [
-    "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
     "@cf/mistralai/mistral-small-3.1-24b-instruct",
     "@cf/qwen/qwen3-30b-a3b-fp8",
     "@cf/qwen/qwen3.8-27b",
     "@cf/zai-org/glm-4.7-flash",
     "@cf/zai-org/glm-5.2",
+    "@cf/zai-org/glm-5.3-flash",
     "@cf/openai/gpt-oss-120b",
     "@cf/openai/gpt-oss-20b",
     "@cf/nvidia/nemotron-3-120b-a12b",

--- a/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
+++ b/libs/langchain-cloudflare/langchain_cloudflare/chat_models.py
@@ -216,13 +216,15 @@ _REASONING_BEHAVIOR = ModelBehavior(
     embed_tool_calls_in_content=False,
     supports_reasoning_content=True,
 )
+_MODERN_GLM_BEHAVIOR = ModelBehavior(
+    embed_tool_calls_in_content=False,
+    unsupported_params=("top_k", "repetition_penalty"),
+    supports_reasoning_content=True,
+)
 
 MODEL_BEHAVIORS: Dict[str, ModelBehavior] = {
-    "glm-5.2": ModelBehavior(
-        embed_tool_calls_in_content=False,
-        unsupported_params=("top_k", "repetition_penalty"),
-        supports_reasoning_content=True,
-    ),
+    "glm-5.3-flash": _MODERN_GLM_BEHAVIOR,
+    "glm-5.2": _MODERN_GLM_BEHAVIOR,
     "glm": ModelBehavior(
         embed_tool_calls_in_content=False,
         unsupported_params=("max_tokens", "top_k", "repetition_penalty", "tool_choice"),

--- a/libs/langchain-cloudflare/pyproject.toml
+++ b/libs/langchain-cloudflare/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-cloudflare"
-version = "0.3.8"
+version = "0.3.9"
 description = "Langchain Integrations for Cloudflare's WorkersAI and Vectorize"
 readme = "README.md"
 license = "MIT"

--- a/libs/langchain-cloudflare/tests/conftest.py
+++ b/libs/langchain-cloudflare/tests/conftest.py
@@ -18,7 +18,7 @@ from dotenv import load_dotenv
 
 # MARK: - Collection Hooks
 
-_LLAMA_STRUCTURED_OUTPUT_TESTS = {
+_STRUCTURED_OUTPUT_STREAMING_TESTS = {
     "test_structured_output",
     "test_structured_output_async",
     "test_structured_output_pydantic_2_v1",
@@ -26,27 +26,26 @@ _LLAMA_STRUCTURED_OUTPUT_TESTS = {
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Mark unsupported inherited Llama structured-output streams as xfail.
+    """Mark unsupported structured-output streaming contracts as xfail.
 
-    The legacy Llama endpoint returns no chunks for structured-output streams
-    even when the equivalent non-streaming invocation succeeds.
-
-    Applying the marker during collection preserves the upstream LangChain test
-    methods. Overriding those methods solely to add a marker violates the
-    ``test_no_overrides_DO_NOT_OVERRIDE`` integration-test contract.
+    Workers AI returns no chunks when LangChain streams a structured-output
+    wrapper, even though equivalent non-streaming calls succeed. Applying the
+    marker during collection preserves the upstream LangChain test methods;
+    overriding them solely to add a marker violates the inherited integration
+    test contract.
     """
     class_node = (
         "tests/integration_tests/test_chat_models.py::TestChatCloudflareWorkersAI::"
     )
     xfail_marker = pytest.mark.xfail(
-        reason="Legacy Llama model does not return structured-output stream chunks",
+        reason="Workers AI structured-output wrappers return no streamed chunks",
         strict=False,
     )
 
     for item in items:
         test_name = item.name.partition("[")[0]
         if item.nodeid.startswith(class_node) and (
-            test_name in _LLAMA_STRUCTURED_OUTPUT_TESTS
+            test_name in _STRUCTURED_OUTPUT_STREAMING_TESTS
         ):
             item.add_marker(xfail_marker)
 

--- a/libs/langchain-cloudflare/tests/integration_tests/test_chat_models.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_chat_models.py
@@ -21,7 +21,7 @@ class TestChatCloudflareWorkersAI(ChatModelIntegrationTests):
     def chat_model_params(self) -> dict:
         """Get the parameters to initialize the chat model."""
         return {
-            "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            "model": "@cf/qwen/qwen3-30b-a3b-fp8",
             "temperature": 0.7,
         }
 

--- a/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
+++ b/libs/langchain-cloudflare/tests/integration_tests/test_workersai_models.py
@@ -84,7 +84,6 @@ FLAKY_MODELS = {
     "@cf/openai/gpt-oss-120b",
     "@cf/openai/gpt-oss-20b",
 }
-LLAMA_3_3_MODEL = "@cf/meta/llama-3.3-70b-instruct-fp8-fast"
 
 
 def _flaky_model_param(model: str) -> str:
@@ -92,15 +91,6 @@ def _flaky_model_param(model: str) -> str:
     return pytest.param(
         model,
         marks=pytest.mark.flaky(reruns=2, reruns_delay=5),
-        id=model,
-    )
-
-
-def _xfail_model_param(model: str, *, reason: str) -> str:
-    """Wrap one legacy-model parameter in a non-strict expected-failure marker."""
-    return pytest.param(
-        model,
-        marks=pytest.mark.xfail(reason=reason, strict=False),
         id=model,
     )
 
@@ -129,12 +119,12 @@ def _model_str(model: object) -> str:
 # (both report "per M cached input tokens" pricing, so k2.6 covers the
 # prompt-caching session-affinity tests k2.5 used to be needed for).
 MODELS = [
-    LLAMA_3_3_MODEL,
     "@cf/mistralai/mistral-small-3.1-24b-instruct",
     "@cf/qwen/qwen3-30b-a3b-fp8",
     "@cf/qwen/qwen3.8-27b",
     "@cf/zai-org/glm-4.7-flash",
     "@cf/zai-org/glm-5.2",
+    "@cf/zai-org/glm-5.3-flash",
     _model_param("@cf/openai/gpt-oss-120b"),
     _model_param("@cf/openai/gpt-oss-20b"),
     "@cf/nvidia/nemotron-3-120b-a12b",
@@ -142,18 +132,6 @@ MODELS = [
     "@cf/deepseek-ai/deepseek-v4-pro-0813",
     "@cf/deepseek-ai/deepseek-v4-flash-0731",
     _model_param("@cf/google/gemma-4-26b-a4b-it"),
-]
-
-TOOL_CALLING_MULTI_TURN_MODELS = [
-    # The legacy Llama model repeats the tool call after receiving its result
-    # instead of returning final content. Scope the xfail to this test only.
-    _xfail_model_param(
-        _model_str(model),
-        reason="Legacy Llama model repeats tool calls instead of returning content",
-    )
-    if _model_str(model) == LLAMA_3_3_MODEL
-    else model
-    for model in MODELS
 ]
 
 # Models live-validated in this suite for method='json_schema'.
@@ -171,6 +149,7 @@ JSON_SCHEMA_MODELS = [
 VISION_MODELS = [
     "@cf/moonshotai/kimi-k2.6",
     "@cf/qwen/qwen3.8-27b",
+    "@cf/zai-org/glm-5.3-flash",
     "@cf/deepseek-ai/deepseek-v4-pro-0813",
     _model_param("@cf/google/gemma-4-26b-a4b-it"),
 ]
@@ -415,7 +394,7 @@ class TestToolCalling:
                 f"  No tool call made, content: {get_text_content(result.content)[:200] if result.content else 'empty'}"
             )
 
-    @pytest.mark.parametrize("model", TOOL_CALLING_MULTI_TURN_MODELS)
+    @pytest.mark.parametrize("model", MODELS)
     def test_tool_calling_multi_turn(self, model, account_id, api_token, ai_gateway):
         """Test multi-turn tool calling conversation.
 
@@ -863,6 +842,7 @@ class TestReasoningContent:
         "@cf/qwen/qwen3.8-27b",
         "@cf/zai-org/glm-4.7-flash",
         "@cf/zai-org/glm-5.2",
+        "@cf/zai-org/glm-5.3-flash",
         _model_param("@cf/openai/gpt-oss-120b"),
         _model_param("@cf/openai/gpt-oss-20b"),
         "@cf/moonshotai/kimi-k2.6",
@@ -986,24 +966,24 @@ class TestReasoningContent:
         else:
             print("  Status: WARN - no tool call made")
 
-    def test_no_reasoning_content_for_llama(self, account_id, api_token, ai_gateway):
-        """Test that Llama content is a plain string, not content blocks."""
+    def test_no_reasoning_content_for_mistral(self, account_id, api_token, ai_gateway):
+        """Test that Mistral content is a plain string, not content blocks."""
         if not account_id or not api_token:
             pytest.skip("Missing CF_ACCOUNT_ID or CF_AI_API_TOKEN")
 
         llm = create_llm(
-            "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            "@cf/mistralai/mistral-small-3.1-24b-instruct",
             account_id,
             api_token,
             ai_gateway,
         )
         result = llm.invoke("Say hello.")
 
-        print("\n[llama] Reasoning Content check:")
+        print("\n[mistral] Reasoning Content check:")
         print(f"  Content type: {type(result.content).__name__}")
 
         assert isinstance(result.content, str), (
-            "Llama should return plain string content, not content blocks"
+            "Mistral should return plain string content, not content blocks"
         )
 
 
@@ -1655,7 +1635,7 @@ class TestAIGatewayHeaders:
     def test_aig_timeout_invoke(self):
         """Request with AI Gateway timeout header should succeed."""
         llm = ChatCloudflareWorkersAI(
-            model="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            model="@cf/qwen/qwen3-30b-a3b-fp8",
             ai_gateway=os.environ["AI_GATEWAY"],
             aig_request_timeout=30000,
         )
@@ -1666,7 +1646,7 @@ class TestAIGatewayHeaders:
     def test_aig_retries_invoke(self):
         """Request with AI Gateway retry headers should succeed."""
         llm = ChatCloudflareWorkersAI(
-            model="@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+            model="@cf/qwen/qwen3-30b-a3b-fp8",
             ai_gateway=os.environ["AI_GATEWAY"],
             aig_max_attempts=2,
             aig_retry_delay=1000,

--- a/libs/langchain-cloudflare/tests/unit_tests/test_chat_models.py
+++ b/libs/langchain-cloudflare/tests/unit_tests/test_chat_models.py
@@ -463,9 +463,13 @@ class TestReasoningContent:
         assert "tool_choice" not in translated
         assert translated["temperature"] == 0.7
 
-    def test_glm_5_2_preserves_supported_params(self):
-        """GLM-5.2 should keep parameters supported by its OpenAI schema."""
-        llm = self._create_llm("@cf/zai-org/glm-5.2")
+    @pytest.mark.parametrize(
+        "model",
+        ["@cf/zai-org/glm-5.2", "@cf/zai-org/glm-5.3-flash"],
+    )
+    def test_modern_glm_preserves_supported_params(self, model):
+        """Modern GLM models should keep parameters supported by their schemas."""
+        llm = self._create_llm(model)
         params = {
             "max_tokens": 100,
             "top_k": 50,

--- a/libs/langchain-cloudflare/tests/worker_tests/test_worker_integration.py
+++ b/libs/langchain-cloudflare/tests/worker_tests/test_worker_integration.py
@@ -86,12 +86,12 @@ def _model_str(model: object) -> str:
 # (both report "per M cached input tokens" pricing, so k2.6 covers the
 # prompt-caching session-affinity tests k2.5 used to be needed for).
 MODELS = [
-    "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
     "@cf/mistralai/mistral-small-3.1-24b-instruct",
     "@cf/qwen/qwen3-30b-a3b-fp8",
     "@cf/qwen/qwen3.8-27b",
     "@cf/zai-org/glm-4.7-flash",
     "@cf/zai-org/glm-5.2",
+    "@cf/zai-org/glm-5.3-flash",
     _model_param("@cf/openai/gpt-oss-120b"),
     _model_param("@cf/openai/gpt-oss-20b"),
     "@cf/nvidia/nemotron-3-120b-a12b",
@@ -116,6 +116,7 @@ JSON_SCHEMA_MODELS = [
 VISION_MODELS = [
     "@cf/moonshotai/kimi-k2.6",
     "@cf/qwen/qwen3.8-27b",
+    "@cf/zai-org/glm-5.3-flash",
     "@cf/deepseek-ai/deepseek-v4-pro-0813",
     _model_param("@cf/google/gemma-4-26b-a4b-it"),
 ]
@@ -1182,6 +1183,7 @@ class TestWorkerReasoningContent:
         "@cf/qwen/qwen3.8-27b",
         "@cf/zai-org/glm-4.7-flash",
         "@cf/zai-org/glm-5.2",
+        "@cf/zai-org/glm-5.3-flash",
         _model_param("@cf/openai/gpt-oss-120b"),
         _model_param("@cf/openai/gpt-oss-20b"),
         "@cf/moonshotai/kimi-k2.6",

--- a/libs/langchain-cloudflare/uv.lock
+++ b/libs/langchain-cloudflare/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "langchain-cloudflare"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1080,7 +1080,7 @@ wheels = [
 
 [[package]]
 name = "langchain-cloudflare"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "libs/langchain-cloudflare" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- add `@cf/zai-org/glm-5.3-flash` to the REST, Python Worker, reasoning, vision, and example model registries
- add model-specific GLM parameter behavior based on the Workers AI schema and live response validation
- remove legacy Llama 3.3 from recurring live model coverage and replace fixed checks with current Qwen or Mistral models
- bump `langchain-cloudflare` to 0.3.9 and update release notes and lockfiles

## Validation

- `make test`: 235 passed, 2 skipped
- fresh isolated Python 3.10 unit suite: 235 passed, 2 skipped
- fresh isolated Python 3.12 unit suite: 235 passed, 2 skipped
- full REST model matrix: 159 passed, 73 skipped
- full Python Worker model matrix: 206 passed, 5 skipped
- inherited LangChain chat-model contracts: 25 passed, 14 skipped, 10 documented expected failures for structured-output streaming
- `make lint`: Ruff check, Ruff format check, and mypy passed
- `pre-commit run --all-files`: passed
- root and package `uv lock --check`: passed
